### PR TITLE
fix: switch deprecated set-env command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: override CI_COMMIT_SHA
         if: github.event_name == 'pull_request'
-        run: echo "::set-env name=CI_COMMIT_SHA::${{ github.event.pull_request.head.sha}}"
+        run: echo "CI_COMMIT_SHA=${{ github.event.pull_request.head.sha}}" >> $GITHUB_ENV
 
       - name: Run bundlemon
         working-directory: ./packages/bundlemon


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/