### PR TITLE
feat: add json output option to save raw results

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -67,3 +67,36 @@ type: `boolean` default: `true`
 Post comment on PR
 
 <img src="../assets/pr-comment.png" alt="pr comment" height="300px" />
+
+## `json`
+
+Save raw results in json file.
+
+### Example
+
+Use default options
+
+```json
+"reportOutput": ["json"]
+```
+
+Override default options
+
+```json
+"reportOutput": [
+  [
+    "json",
+    {
+      "fileName": "fantastic-file-name.json"
+    }
+  ]
+]
+```
+
+### Options
+
+#### `fileName`
+
+type: `string` default: `bundlemon-results.json`
+
+Use custom file name for results.

--- a/packages/bundlemon/src/main/outputs/outputs/index.ts
+++ b/packages/bundlemon/src/main/outputs/outputs/index.ts
@@ -1,9 +1,10 @@
 /* istanbul ignore file */
 import consoleOutput from './console';
 import githubOutput from './github';
+import jsonOutput from './json';
 
 import type { Output } from '../types';
 
-const outputs: Output[] = [consoleOutput, githubOutput];
+const outputs: Output[] = [consoleOutput, githubOutput, jsonOutput];
 
 export const getAllOutputs = (): Output[] => outputs;

--- a/packages/bundlemon/src/main/outputs/outputs/json.ts
+++ b/packages/bundlemon/src/main/outputs/outputs/json.ts
@@ -15,10 +15,10 @@ interface JsonOutputOptions {
 }
 
 function validateOptions(options: unknown): JsonOutputOptions | undefined {
-  const schema = yup
+  const schema: yup.SchemaOf<JsonOutputOptions, JsonOutputOptions> = yup
     .object()
     .required()
-    .shape<JsonOutputOptions>({
+    .shape({
       fileName: yup.string().optional().default(DEFAULT_FILENAME),
     });
 

--- a/packages/bundlemon/src/main/outputs/outputs/json.ts
+++ b/packages/bundlemon/src/main/outputs/outputs/json.ts
@@ -1,0 +1,53 @@
+import * as yup from 'yup';
+import fs from 'fs';
+import { Report } from 'bundlemon-utils';
+import { createLogger } from '../../../common/logger';
+import { validateYup } from '../../utils/validationUtils';
+import type { Output, OutputInstance } from '../types';
+
+const NAME = 'json';
+const DEFAULT_FILENAME = 'bundlemon-results.json';
+
+const logger = createLogger(`${NAME} output`);
+
+interface JsonOutputOptions {
+  fileName: string;
+}
+
+function validateOptions(options: unknown): JsonOutputOptions | undefined {
+  const schema = yup
+    .object()
+    .required()
+    .shape<JsonOutputOptions>({
+      fileName: yup.string().optional().default(DEFAULT_FILENAME),
+    });
+
+  return validateYup(schema, options, `${NAME} output`);
+}
+
+const saveAsJson = (filename: string, payload: Report) => {
+  try {
+    fs.writeFileSync(`${filename}`, JSON.stringify(payload, null, 2));
+  } catch (error) {
+    logger.error(`Could not save a file ${filename}`);
+    throw error;
+  }
+};
+
+const output: Output = {
+  name: NAME,
+  create: ({ options }): OutputInstance | Promise<OutputInstance | undefined> | undefined => {
+    const normalizedOptions = validateOptions(options);
+
+    if (!normalizedOptions) {
+      throw new Error(`validation error in output "${NAME}" options`);
+    }
+    return {
+      generate: (report: Report): void => {
+        saveAsJson(normalizedOptions.fileName, report);
+      },
+    };
+  },
+};
+
+export default output;

--- a/packages/bundlemon/src/main/utils/configUtils.ts
+++ b/packages/bundlemon/src/main/utils/configUtils.ts
@@ -36,8 +36,8 @@ function getConfigSchema() {
         .test(
           'maxSize',
           (params) => `${params.path} not a valid max size`,
-          (value: string | undefined) => {
-            if (value === undefined) {
+          (value: string | null | undefined) => {
+            if (!value) {
               return true;
             }
             const sizeInBytes = bytes(value);

--- a/packages/bundlemon/src/main/utils/configUtils.ts
+++ b/packages/bundlemon/src/main/utils/configUtils.ts
@@ -37,7 +37,7 @@ function getConfigSchema() {
           'maxSize',
           (params) => `${params.path} not a valid max size`,
           (value: string | null | undefined) => {
-            if (!value) {
+            if (value === undefined || value === null) {
               return true;
             }
             const sizeInBytes = bytes(value);


### PR DESCRIPTION
Addresses https://github.com/LironEr/bundlemon/issues/55
## User story
As an user I would like to save results as json file so that results can be further processed for example by CI scripts.

### Use cases
`json` output format can be provided in `reportOutput`
```json
"reportOutput": ["json"]
```
Which will save results by default as `bundlemon-results.json`. Default file name can be overridden with `fileName` option.
```json
"reportOutput": [
  [
    "json",
    {
      "fileName": "fantastic-file-name.json"
    }
  ]
]
```
Example output:
![Screenshot 2021-10-29 at 16 45 04](https://user-images.githubusercontent.com/58426925/139455380-5106f05f-e9e8-448b-89d6-f05fa5bc9075.png)

### Additional info
I also fixed little issue with typescript error when trying to build the project (commit 2dc14f6)
![Screenshot 2021-10-29 at 16 34 40](https://user-images.githubusercontent.com/58426925/139455029-3eef7c88-a2cb-440d-9b46-a6346f1172fc.png)

```sh
bundlemon: yarn run v1.22.17
bundlemon: $ rimraf lib/ && tsc -p tsconfig.release.json
bundlemon: src/main/utils/configUtils.ts(39,11): error TS2769: No overload matches this call.
bundlemon:   Overload 1 of 4, '(name: string, message: TestOptionsMessage<{}, any>, test: TestFunction<string | null | undefined, object>): StringSchema<string | undefined, object>', gave the following error.
bundlemon:     Argument of type '(value: string | undefined) => boolean' is not assignable to parameter of type 'TestFunction<string | null | undefined, object>'.
bundlemon:       Types of parameters 'value' and 'value' are incompatible.
bundlemon:         Type 'string | null | undefined' is not assignable to type 'string | undefined'.
bundlemon:           Type 'null' is not assignable to type 'string | undefined'.
bundlemon:   Overload 2 of 4, '(name: string, message: TestOptionsMessage<{}, any>, test: AssertingTestFunction<any, object>): StringSchema<any, object>', gave the following error.
bundlemon:     Argument of type '(value: string | undefined) => boolean' is not assignable to parameter of type 'AssertingTestFunction<any, object>'.
bundlemon:       Signature '(value: string | undefined): boolean' must be a type predicate.
```