### PR TITLE
fix(website): apply higher z-index for chart tooltip so that table header doesn't cover it

### DIFF
--- a/website/src/pages/ReportsPage/components/ReportsChart/ReportsChart.tsx
+++ b/website/src/pages/ReportsPage/components/ReportsChart/ReportsChart.tsx
@@ -10,6 +10,10 @@ interface ReportsChartProps {
   store: ReportsStore;
 }
 
+const toolTipStyle = {
+  ['z-index']: '3',
+};
+
 const ReportsChart = observer(({ store }: ReportsChartProps) => {
   return (
     <>
@@ -26,7 +30,7 @@ const ReportsChart = observer(({ store }: ReportsChartProps) => {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="creationDate" tickFormatter={dateTickFormatter} />
           <YAxis tickFormatter={bytesTickFormatter} domain={['auto', 'auto']} />
-          <Tooltip formatter={(value) => bytes(value as number)} />
+          <Tooltip wrapperStyle={toolTipStyle} formatter={(value) => bytes(value as number)} />
           {store.pathRecords.map((record) => (
             <Line
               key={record.path}


### PR DESCRIPTION
Addresses https://github.com/LironEr/bundlemon/issues/60

**Description:**

Sticky header of the table https://mui.com/components/tables/#sticky-header was displayed above the chart tooltip.
My fix proposal is to use `wrapperStyle` Tooltip option https://recharts.org/en-US/api/Tooltip#wrapperStyle to set a higher z-index than the MUI Table header has. However I'm not sure if this is a correct way of fixing such issue. 

**Before:**
<img width="1754" alt="139408046-5db1bf46-252c-46fc-bdf8-0e434d846782" src="https://user-images.githubusercontent.com/58426925/139463923-66d8aa65-a76c-46d5-b5bd-73e9317d5a1b.png">

**After:**
![Screenshot 2021-10-29 at 17 29 50](https://user-images.githubusercontent.com/58426925/139463948-d9f1efe4-79ab-4987-b159-672687e21eba.png)
