### PR TITLE
Improve report text to have numbers first

### DIFF
--- a/packages/bundlemon-utils/src/textUtils.ts
+++ b/packages/bundlemon-utils/src/textUtils.ts
@@ -43,9 +43,9 @@ export function getReportConclusionText(report: Report): string {
   if (status === Status.Pass) {
     return stats.diff.bytes === 0
       ? 'No change in files bundle size'
-      : `Total files change ${getDiffSizeText(stats.diff.bytes)} ${
+      : `${getDiffSizeText(stats.diff.bytes)} ${
           Number.isFinite(stats.diff.percent) ? getDiffPercentText(stats.diff.percent) : ''
-        }`;
+        } total files change`;
   }
 
   const fileFails = files.filter((f) => f.status === Status.Fail);


### PR DESCRIPTION
Hi @LironEr, currently BundleMon reports look like this in the checks popup:

<img width="526" alt="image" src="https://user-images.githubusercontent.com/25395/165530357-f5e01ffd-3825-4489-8a08-94137ef9dce0.png">

You have to click and navigate to a separate page to see the actual change, which is very inconvenient. I suggest changing the order in the conclusion text so that the numbers come first, so that they're immediately visible in GitHub UI, making the reports much more convenient.