### PR TITLE
BREAKING CHANGE: use new auth

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,8 @@
       "rules": {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-empty-function": "off",
-        "@typescript-eslint/no-var-requires": "off"
+        "@typescript-eslint/no-var-requires": "off",
+        "jest/no-disabled-tests": "off"
       }
     }
   ],

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -32,3 +32,4 @@ jobs:
         run: yarn bundlemon
         env:
           CI_COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}} # important!
+          BUNDLEMON_SERVICE_URL: https://bundlemon-api-lironer.vercel.app

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -31,5 +31,4 @@ jobs:
         working-directory: ./website
         run: yarn bundlemon
         env:
-          BUNDLEMON_PROJECT_ID: 60a928cfc1ab380009f5cc0b
           CI_COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}} # important!

--- a/README.md
+++ b/README.md
@@ -83,27 +83,6 @@ bundlemon --config my-custom-config-path.json
 
 [CLI flags docs](./docs/cli-flags.md)
 
-## Create new project
-
-In order to save history and get differences from your main branches you will need to create a new project and setup environment variables.
-
-- [Create new project](https://app.bundlemon.dev/create-project) and copy the project ID and API key
-- Add the ID to `BUNDLEMON_PROJECT_ID` and the API key to `BUNDLEMON_PROJECT_APIKEY` environment variables in your CI
-
-## Set additional environment variables
-
-In order to get BundleMon to work you'll need to set these environment variables:
-
-> If you are using one of the supported CIs (GitHub Actions, Travis, CircleCI and Codefresh) you dont need to set anything.
-
-- `CI=true`
-- `CI_REPO_OWNER` - github.com/LironEr/bundlemon `LironEr`
-- `CI_REPO_NAME` - github.com/LironEr/bundlemon `bundlemon`
-- `CI_BRANCH` - source branch name
-- `CI_COMMIT_SHA` - commit SHA
-- `CI_TARGET_BRANCH` - target branch name, only set if BundleMon runs on a pull request
-- `CI_PR_NUMBER` - PR number, only set if BundleMon runs on a pull request
-
 ## Using hash in file names?
 
 When using hash in file names the file name can be changed every build.
@@ -143,6 +122,17 @@ Output:
 [PASS] login.(hash).chunk.js: 3.37KB < 50KB
 ```
 
+## BundleMon Project
+
+In order to save history and get differences from your main branches BundleMon will need a project id.
+
+**If you are running BundleMon in GitHub actions** BundleMon will detect all necessary information automatically, Just [Install BundleMon GitHub App](https://github.com/apps/bundlemon).
+
+**If not**, you will need to create a new project and setup environment variables.
+
+- [Create new project](https://app.bundlemon.dev/create-project) and copy the project ID and API key
+- Add the ID to `BUNDLEMON_PROJECT_ID` and the API key to `BUNDLEMON_PROJECT_APIKEY` environment variables in your CI
+
 ## GitHub integration
 
 BundleMon can create GitHub check run, post commit status and a detailed comment on your PR.
@@ -153,9 +143,16 @@ BundleMon can create GitHub check run, post commit status and a detailed comment
 <br />
 <img src="./assets/pr-comment.png" alt="GitHub detailed comment" height="300px" />
 
-Just [Install BundleMon GitHub App](https://github.com/apps/bundlemon)
+1. Setup integration
 
-Then add `github` to `reportOutput`
+   - If BundleMon runs in GitHub actions and you already [Installed BundleMon GitHub App](https://github.com/apps/bundlemon) you can go to step 2.
+   - If BundleMon not runs In GitHub actions you will need to create GitHub access token.
+
+     Add the token to `BUNDLEMON_GITHUB_TOKEN` environment variable in your CI.
+
+     > The token is not saved in BundleMon service, ONLY used to communicate with GitHub
+
+2. Add `github` to `reportOutput`
 
 ```json
 "reportOutput": ["github"]
@@ -166,7 +163,7 @@ Then add `github` to `reportOutput`
   [
     "github",
     {
-      "checkRun": false,
+      "checkRun": false, // Only works if using Bundlemon GitHub App
       "commitStatus": true,
       "prComment": true
     }
@@ -176,7 +173,7 @@ Then add `github` to `reportOutput`
 
 ### GitHub action example & forks support
 
-BundleMon supports running on PRs originating from forks, ONLY on **public** repos and by removing `BUNDLEMON_PROJECT_APIKEY` variable.
+BundleMon supports running on PRs originating from forks.
 
 [Step by step guide to set up BundleMon with Github actions](https://github.com/LironEr/bundlemon-github-actions)
 
@@ -208,17 +205,25 @@ jobs:
       - name: Run BundleMon
         run: yarn bundlemon
         env:
-          BUNDLEMON_PROJECT_ID: YOUR_PROJECT_ID
-          BUNDLEMON_PROJECT_APIKEY: ${{ secrets.BUNDLEMON_PROJECT_APIKEY }} # not required for public repos
           CI_COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}} # important!
 ```
 
 > Make sure to set `CI_COMMIT_SHA` env var, more info can be found [here](https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout)
 
+## Set additional environment variables
+
+In order to get BundleMon to work you'll need to set these environment variables:
+
+> If you are using one of the supported CIs (GitHub Actions, Travis, CircleCI and Codefresh) you dont need to set anything.
+
+- `CI=true`
+- `CI_REPO_OWNER` - github.com/LironEr/bundlemon `LironEr`
+- `CI_REPO_NAME` - github.com/LironEr/bundlemon `bundlemon`
+- `CI_BRANCH` - source branch name
+- `CI_COMMIT_SHA` - commit SHA
+- `CI_TARGET_BRANCH` - target branch name, only set if BundleMon runs on a pull request
+- `CI_PR_NUMBER` - PR number, only set if BundleMon runs on a pull request
+
 ## Contributing
 
 Read the [contributing guide](./CONTRIBUTING.md) to learn how to run this project locally and contribute.
-
-## Credits
-
-- Inspired by [BundleWatch](https://github.com/bundlewatch/bundlewatch)

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ BundleMon can create GitHub check run, post commit status and a detailed comment
 1. Setup integration
 
    - If BundleMon runs in GitHub actions and you already [Installed BundleMon GitHub App](https://github.com/apps/bundlemon) you can go to step 2.
-   - If BundleMon not runs In GitHub actions you will need to create GitHub access token.
+   - If BundleMon not runs In GitHub actions you will need to [create GitHub access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 
      Add the token to `BUNDLEMON_GITHUB_TOKEN` environment variable in your CI.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,6 @@ flags:
   service:
     paths:
       - service/
+coverage:
+  status:
+    patch: off

--- a/packages/bundlemon/src/common/__tests__/__snapshots__/consts.spec.ts.snap
+++ b/packages/bundlemon/src/common/__tests__/__snapshots__/consts.spec.ts.snap
@@ -2,6 +2,10 @@
 
 exports[`consts default snapshot 1`] = `
 Object {
+  "CreateCommitRecordAuthType": Object {
+    "GithubActions": "GITHUB_ACTIONS",
+    "ProjectApiKey": "PROJECT_API_KEY",
+  },
   "EnvVar": Object {
     "projectApiKey": "BUNDLEMON_PROJECT_APIKEY",
     "projectId": "BUNDLEMON_PROJECT_ID",

--- a/packages/bundlemon/src/common/consts.ts
+++ b/packages/bundlemon/src/common/consts.ts
@@ -12,3 +12,8 @@ export const serviceUrl = process.env[EnvVar.serviceURL] || 'https://api.bundlem
 const packageJSON = require('../../package.json');
 
 export const version = packageJSON.version;
+
+export enum CreateCommitRecordAuthType {
+  ProjectApiKey = 'PROJECT_API_KEY',
+  GithubActions = 'GITHUB_ACTIONS',
+}

--- a/packages/bundlemon/src/common/service.ts
+++ b/packages/bundlemon/src/common/service.ts
@@ -1,9 +1,9 @@
-import axios, { AxiosError, AxiosRequestHeaders } from 'axios';
+import axios, { AxiosError } from 'axios';
 import { createLogger } from './logger';
 import { serviceUrl, version } from './consts';
 
 import type { CommitRecordPayload, CreateCommitRecordResponse } from 'bundlemon-utils';
-import type { AuthHeaders } from '../main/types';
+import type { CreateCommitRecordAuthParams, GitDetails } from '../main/types';
 
 export const serviceClient = axios.create({
   baseURL: `${serviceUrl}/v1`,
@@ -48,16 +48,28 @@ function logError(err: Error | AxiosError, prefix: string) {
 export async function createCommitRecord(
   projectId: string,
   payload: CommitRecordPayload,
-  authHeaders: AuthHeaders
+  authParams: CreateCommitRecordAuthParams
 ): Promise<CreateCommitRecordResponse | undefined> {
   try {
     const res = await serviceClient.post<CreateCommitRecordResponse>(`/projects/${projectId}/commit-records`, payload, {
-      headers: authHeaders as unknown as AxiosRequestHeaders,
+      params: authParams,
     });
 
     return res.data;
   } catch (err) {
     logError(err as Error, 'create commit record');
+  }
+
+  return undefined;
+}
+
+export async function getOrCreateProjectId(details: GitDetails): Promise<string | undefined> {
+  try {
+    const res = await serviceClient.post<{ id: string }>(`/projects/id`, details);
+
+    return res.data.id;
+  } catch (err) {
+    logError(err as Error, 'get or create project id');
   }
 
   return undefined;

--- a/packages/bundlemon/src/common/service.ts
+++ b/packages/bundlemon/src/common/service.ts
@@ -63,9 +63,17 @@ export async function createCommitRecord(
   return undefined;
 }
 
-export async function getOrCreateProjectId(details: GitDetails): Promise<string | undefined> {
+type GithubProviderAuthQuery = {
+  runId: string;
+  commitSha: string;
+};
+
+export async function getOrCreateProjectId(
+  details: GitDetails,
+  auth: GithubProviderAuthQuery
+): Promise<string | undefined> {
   try {
-    const res = await serviceClient.post<{ id: string }>(`/projects/id`, details);
+    const res = await serviceClient.post<{ id: string }>(`/projects/id`, details, { params: auth });
 
     return res.data.id;
   } catch (err) {

--- a/packages/bundlemon/src/main/__tests__/initializer.spec.ts
+++ b/packages/bundlemon/src/main/__tests__/initializer.spec.ts
@@ -21,7 +21,7 @@ describe('initializer', () => {
   });
 
   test('validate config failed', async () => {
-    const mockedValidateConfig = mocked(validateConfig).mockReturnValue(undefined);
+    const mockedValidateConfig = mocked(validateConfig).mockResolvedValue(undefined);
 
     const result = await initializer(config);
 
@@ -31,7 +31,7 @@ describe('initializer', () => {
 
   test('base dir not found', async () => {
     const expectedNormalizedConfig = generateNormalizedConfigRemoteOn();
-    const mockedValidateConfig = mocked(validateConfig).mockReturnValue(expectedNormalizedConfig);
+    const mockedValidateConfig = mocked(validateConfig).mockResolvedValue(expectedNormalizedConfig);
     const mockedExistsSync = mocked(fs.existsSync).mockReturnValue(false);
 
     const result = await initializer(config);
@@ -43,7 +43,7 @@ describe('initializer', () => {
 
   test('failed to initialize outputs', async () => {
     const expectedNormalizedConfig = generateNormalizedConfigRemoteOn();
-    const mockedValidateConfig = mocked(validateConfig).mockReturnValue(expectedNormalizedConfig);
+    const mockedValidateConfig = mocked(validateConfig).mockResolvedValue(expectedNormalizedConfig);
     const mockedExistsSync = mocked(fs.existsSync).mockReturnValue(true);
     const mockedInitOutputs = mocked(initOutputs).mockRejectedValue(new Error('error'));
 
@@ -57,7 +57,7 @@ describe('initializer', () => {
 
   test('success', async () => {
     const expectedNormalizedConfig = generateNormalizedConfigRemoteOn();
-    const mockedValidateConfig = mocked(validateConfig).mockReturnValue(expectedNormalizedConfig);
+    const mockedValidateConfig = mocked(validateConfig).mockResolvedValue(expectedNormalizedConfig);
     const mockedExistsSync = mocked(fs.existsSync).mockReturnValue(true);
     const mockedInitOutputs = mocked(initOutputs).mockResolvedValue();
 

--- a/packages/bundlemon/src/main/initializer.ts
+++ b/packages/bundlemon/src/main/initializer.ts
@@ -11,7 +11,7 @@ export async function initializer(config: Config): Promise<NormalizedConfig | un
 
   logger.info(`Start BundleMon v${version}`);
 
-  const normalizedConfig = Object.freeze(validateConfig(config));
+  const normalizedConfig = Object.freeze(await validateConfig(config));
 
   if (!normalizedConfig) {
     logger.debug(`Config\n${JSON.stringify(config, null, 2)}`);

--- a/packages/bundlemon/src/main/outputs/outputs/github.ts
+++ b/packages/bundlemon/src/main/outputs/outputs/github.ts
@@ -67,12 +67,12 @@ const output: Output = {
     let authParams: GitHubOutputAuthParams;
 
     const ciVars = getCIVars();
-    const githubToken = getEnvVar('BUNDLEMON_GITHUB_TOKEN') || getEnvVar('GITHUB_TOKEN');
+    const githubToken = getEnvVar('BUNDLEMON_GITHUB_TOKEN');
 
-    if (ciVars.provider == 'github' && ciVars.buildId) {
-      authParams = { runId: ciVars.buildId };
-    } else if (githubToken) {
+    if (githubToken) {
       authParams = { token: githubToken };
+    } else if (ciVars.provider == 'github' && ciVars.buildId) {
+      authParams = { runId: ciVars.buildId };
     } else {
       throw new Error('Missing GitHub actions run id or GitHub token');
     }

--- a/packages/bundlemon/src/main/report/__tests__/generateReport.spec.ts
+++ b/packages/bundlemon/src/main/report/__tests__/generateReport.spec.ts
@@ -117,7 +117,7 @@ describe('generateReport', () => {
           files: localFiles,
           groups: localGroups,
         },
-        config.getAuthHeaders()
+        config.getCreateCommitRecordAuthParams()
       );
       expect(generateDiffReport).toHaveBeenCalledWith({ files: localFiles, groups: localGroups }, undefined);
       expect(result).toEqual(expectedResult);
@@ -151,7 +151,7 @@ describe('generateReport', () => {
           files: localFiles,
           groups: localGroups,
         },
-        config.getAuthHeaders()
+        config.getCreateCommitRecordAuthParams()
       );
       expect(generateDiffReport).toHaveBeenCalledWith(
         { files: localFiles, groups: localGroups },
@@ -175,7 +175,7 @@ describe('generateReport', () => {
           files: localFiles,
           groups: localGroups,
         },
-        config.getAuthHeaders()
+        config.getCreateCommitRecordAuthParams()
       );
       expect(generateDiffReport).toHaveBeenCalledTimes(0);
       expect(result).toEqual(undefined);

--- a/packages/bundlemon/src/main/report/generateReport.ts
+++ b/packages/bundlemon/src/main/report/generateReport.ts
@@ -26,7 +26,7 @@ export async function generateReport(config: NormalizedConfig, input: DiffReport
         ...gitVars,
         ...input,
       },
-      config.getAuthHeaders()
+      config.getCreateCommitRecordAuthParams()
     );
 
     if (!result) {

--- a/packages/bundlemon/src/main/types.ts
+++ b/packages/bundlemon/src/main/types.ts
@@ -1,4 +1,5 @@
-import type { Compression } from 'bundlemon-utils';
+import type { Compression, ProjectProvider } from 'bundlemon-utils';
+import type { CreateCommitRecordAuthType } from '../common/consts';
 
 export interface FileConfig {
   friendlyName?: string;
@@ -34,7 +35,7 @@ export interface NormalizedConfigRemoteOn extends BaseNormalizedConfig {
   remote: true;
   projectId: string;
   gitVars: GitVars;
-  getAuthHeaders: () => AuthHeaders;
+  getCreateCommitRecordAuthParams: () => CreateCommitRecordAuthParams;
 }
 
 export interface NormalizedConfigRemoteOff extends BaseNormalizedConfig {
@@ -55,16 +56,22 @@ export interface GitVars {
   prNumber?: string;
 }
 
-export interface ProjectAuthHeaders {
-  'BundleMon-Auth-Type': 'API_KEY';
-  'x-api-key': string;
-}
+export type CreateCommitRecordProjectApiKeyAuthQuery = {
+  authType: CreateCommitRecordAuthType.ProjectApiKey;
+  token: string;
+};
 
-export interface GithubActionsAuthHeaders {
-  'BundleMon-Auth-Type': 'GITHUB_ACTION';
-  'GitHub-Owner': string;
-  'GitHub-Repo': string;
-  'GitHub-Run-ID': string;
-}
+export type CreateCommitRecordGithubActionsAuthQuery = {
+  authType: CreateCommitRecordAuthType.GithubActions;
+  runId: string;
+};
 
-export type AuthHeaders = ProjectAuthHeaders | GithubActionsAuthHeaders;
+export type CreateCommitRecordAuthParams =
+  | CreateCommitRecordProjectApiKeyAuthQuery
+  | CreateCommitRecordGithubActionsAuthQuery;
+
+export interface GitDetails {
+  provider: ProjectProvider;
+  owner: string;
+  repo: string;
+}

--- a/packages/bundlemon/src/main/utils/__tests__/configUtils.ts
+++ b/packages/bundlemon/src/main/utils/__tests__/configUtils.ts
@@ -1,5 +1,11 @@
 import { Compression } from 'bundlemon-utils';
-import { BaseNormalizedConfig, NormalizedConfigRemoteOn, NormalizedConfigRemoteOff, AuthHeaders } from '../../types';
+import { CreateCommitRecordAuthType } from '../../../common/consts';
+import {
+  BaseNormalizedConfig,
+  NormalizedConfigRemoteOn,
+  NormalizedConfigRemoteOff,
+  CreateCommitRecordAuthParams,
+} from '../../types';
 
 const baseNormalizedConfig: Omit<BaseNormalizedConfig, 'remote'> = {
   baseDir: '',
@@ -13,9 +19,9 @@ const baseNormalizedConfig: Omit<BaseNormalizedConfig, 'remote'> = {
 export function generateNormalizedConfigRemoteOn(
   override: Partial<NormalizedConfigRemoteOn> = {}
 ): NormalizedConfigRemoteOn {
-  const authHeaders: AuthHeaders = {
-    'BundleMon-Auth-Type': 'API_KEY',
-    'x-api-key': generateRandomString(),
+  const authHeaders: CreateCommitRecordAuthParams = {
+    authType: CreateCommitRecordAuthType.ProjectApiKey,
+    token: generateRandomString(),
   };
 
   return {
@@ -26,7 +32,7 @@ export function generateNormalizedConfigRemoteOn(
       branch: generateRandomString(),
       commitSha: generateRandomString(),
     },
-    getAuthHeaders: () => authHeaders,
+    getCreateCommitRecordAuthParams: () => authHeaders,
     ...override,
   };
 }

--- a/packages/bundlemon/src/main/utils/configUtils.ts
+++ b/packages/bundlemon/src/main/utils/configUtils.ts
@@ -183,11 +183,14 @@ async function getProjectId(ciVars: CIEnvVars) {
   let projectId = process.env[EnvVar.projectId];
 
   if (!projectId) {
-    const { provider, owner, repo } = ciVars;
+    const { provider, owner, repo, buildId, commitSha } = ciVars;
 
-    if (provider === ProjectProvider.GitHub && owner && repo) {
+    if (provider === ProjectProvider.GitHub && owner && repo && buildId && commitSha) {
       logger.info('fetch project id');
-      projectId = await getOrCreateProjectId({ provider: provider as ProjectProvider, owner, repo });
+      projectId = await getOrCreateProjectId(
+        { provider: ProjectProvider.GitHub, owner, repo },
+        { runId: buildId, commitSha }
+      );
 
       if (!projectId) {
         logger.error(`Project id returned undefined`);

--- a/packages/bundlemon/src/main/utils/configUtils.ts
+++ b/packages/bundlemon/src/main/utils/configUtils.ts
@@ -179,8 +179,8 @@ export function getCreateCommitRecordAuthParams(ciVars: CIEnvVars): CreateCommit
   return undefined;
 }
 
-async function getProjectId(ciVars: CIEnvVars) {
-  let projectId = process.env[EnvVar.projectId];
+export async function getProjectId(ciVars: CIEnvVars) {
+  let projectId = getEnvVar(EnvVar.projectId);
 
   if (!projectId) {
     const { provider, owner, repo, buildId, commitSha } = ciVars;

--- a/service/src/consts/__tests__/__snapshots__/commitRecords.spec.ts.snap
+++ b/service/src/consts/__tests__/__snapshots__/commitRecords.spec.ts.snap
@@ -14,6 +14,7 @@ Object {
   },
   "CreateCommitRecordAuthType": Object {
     "GithubActions": "GITHUB_ACTIONS",
+    "ProjectApiKey": "PROJECT_API_KEY",
   },
 }
 `;

--- a/service/src/consts/commitRecords.ts
+++ b/service/src/consts/commitRecords.ts
@@ -11,5 +11,6 @@ export enum BaseRecordCompareTo {
 }
 
 export enum CreateCommitRecordAuthType {
+  ProjectApiKey = 'PROJECT_API_KEY',
   GithubActions = 'GITHUB_ACTIONS',
 }

--- a/service/src/consts/projects.ts
+++ b/service/src/consts/projects.ts
@@ -1,0 +1,3 @@
+export enum GetOrCreateProjectIdAuthType {
+  GithubActions = 'GITHUB_ACTIONS',
+}

--- a/service/src/consts/projects.ts
+++ b/service/src/consts/projects.ts
@@ -1,3 +1,0 @@
-export enum GetOrCreateProjectIdAuthType {
-  GithubActions = 'GITHUB_ACTIONS',
-}

--- a/service/src/consts/schemas.ts
+++ b/service/src/consts/schemas.ts
@@ -953,44 +953,44 @@ export const GetOrCreateProjectIdRequestSchema = {
   type: 'object',
   properties: {
     body: {
-      $ref: '#/definitions/GitDetails',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        provider: {
+          type: 'string',
+          const: 'github',
+        },
+        owner: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 100,
+          pattern: '^[a-zA-Z0-9_.-]*$',
+        },
+        repo: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 100,
+          pattern: '^[a-zA-Z0-9_.-]*$',
+        },
+      },
+      required: ['owner', 'provider', 'repo'],
     },
-    query: {},
-    params: {},
-    headers: {},
+    query: {
+      type: 'object',
+      properties: {
+        runId: {
+          type: 'string',
+        },
+        commitSha: {
+          type: 'string',
+        },
+      },
+      required: ['runId', 'commitSha'],
+      additionalProperties: false,
+    },
   },
-  required: ['body'],
+  required: ['body', 'query'],
   additionalProperties: false,
-};
-
-export const GitDetails = {
-  $id: '#/definitions/GitDetails',
-  type: 'object',
-  properties: {
-    provider: {
-      $ref: '#/definitions/ProjectProvider',
-    },
-    owner: {
-      type: 'string',
-      minLength: 1,
-      maxLength: 100,
-      pattern: '^[a-zA-Z0-9_.-]*$',
-    },
-    repo: {
-      type: 'string',
-      minLength: 1,
-      maxLength: 100,
-      pattern: '^[a-zA-Z0-9_.-]*$',
-    },
-  },
-  required: ['provider', 'owner', 'repo'],
-  additionalProperties: false,
-};
-
-export const ProjectProvider = {
-  $id: '#/definitions/ProjectProvider',
-  type: 'string',
-  const: 'github',
 };
 
 export const GetSubprojectsRequestSchema = {

--- a/service/src/consts/schemas.ts
+++ b/service/src/consts/schemas.ts
@@ -88,6 +88,22 @@ export const ProjectIdParams = {
   additionalProperties: false,
 };
 
+export const CreateCommitRecordProjectApiKeyAuthQuery = {
+  $id: '#/definitions/CreateCommitRecordProjectApiKeyAuthQuery',
+  type: 'object',
+  properties: {
+    authType: {
+      type: 'string',
+      const: 'PROJECT_API_KEY',
+    },
+    token: {
+      type: 'string',
+    },
+  },
+  required: ['authType', 'token'],
+  additionalProperties: false,
+};
+
 export const CreateCommitRecordGithubActionsAuthQuery = {
   $id: '#/definitions/CreateCommitRecordGithubActionsAuthQuery',
   type: 'object',
@@ -107,6 +123,9 @@ export const CreateCommitRecordGithubActionsAuthQuery = {
 export const CreateCommitRecordRequestQuery = {
   $id: '#/definitions/CreateCommitRecordRequestQuery',
   anyOf: [
+    {
+      $ref: '#/definitions/CreateCommitRecordProjectApiKeyAuthQuery',
+    },
     {
       $ref: '#/definitions/CreateCommitRecordGithubActionsAuthQuery',
     },
@@ -858,52 +877,23 @@ export const GithubOutputRequestSchema = {
       type: 'object',
       properties: {
         git: {
-          anyOf: [
-            {
-              type: 'object',
-              additionalProperties: false,
-              properties: {
-                token: {
-                  type: 'string',
-                },
-                owner: {
-                  type: 'string',
-                },
-                repo: {
-                  type: 'string',
-                },
-                commitSha: {
-                  type: 'string',
-                },
-                prNumber: {
-                  type: 'string',
-                },
-              },
-              required: ['commitSha', 'owner', 'repo', 'token'],
+          type: 'object',
+          properties: {
+            owner: {
+              type: 'string',
             },
-            {
-              type: 'object',
-              additionalProperties: false,
-              properties: {
-                runId: {
-                  type: 'string',
-                },
-                owner: {
-                  type: 'string',
-                },
-                repo: {
-                  type: 'string',
-                },
-                commitSha: {
-                  type: 'string',
-                },
-                prNumber: {
-                  type: 'string',
-                },
-              },
-              required: ['commitSha', 'owner', 'repo', 'runId'],
+            repo: {
+              type: 'string',
             },
-          ],
+            commitSha: {
+              type: 'string',
+            },
+            prNumber: {
+              type: 'string',
+            },
+          },
+          required: ['owner', 'repo', 'commitSha'],
+          additionalProperties: false,
         },
         output: {
           type: 'object',
@@ -920,8 +910,32 @@ export const GithubOutputRequestSchema = {
           },
           additionalProperties: false,
         },
+        auth: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                token: {
+                  type: 'string',
+                },
+              },
+              required: ['token'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: {
+                runId: {
+                  type: 'string',
+                },
+              },
+              required: ['runId'],
+              additionalProperties: false,
+            },
+          ],
+        },
       },
-      required: ['git', 'output'],
+      required: ['git', 'output', 'auth'],
       additionalProperties: false,
     },
     query: {},

--- a/service/src/controllers/commitRecordsController.ts
+++ b/service/src/controllers/commitRecordsController.ts
@@ -31,7 +31,7 @@ export const createCommitRecordController: FastifyValidatedRoute<CreateCommitRec
   const authResult = await checkAuth(projectId, headers, query, body.commitSha, req.log);
 
   if (!authResult.authenticated) {
-    res.status(403).send({ error: authResult.error });
+    res.status(403).send({ error: authResult.error, extraData: authResult.extraData });
     return;
   }
 

--- a/service/src/controllers/commitRecordsController.ts
+++ b/service/src/controllers/commitRecordsController.ts
@@ -9,6 +9,7 @@ import type {
   GetCommitRecordRequestSchema,
   GetCommitRecordsRequestSchema,
 } from '../types/schemas';
+
 import type { CommitRecord, CreateCommitRecordResponse } from 'bundlemon-utils';
 
 export const getCommitRecordsController: FastifyValidatedRoute<GetCommitRecordsRequestSchema> = async (req, res) => {

--- a/service/src/controllers/projectsController.ts
+++ b/service/src/controllers/projectsController.ts
@@ -1,9 +1,11 @@
 import { randomBytes } from 'crypto';
+import { ProjectProvider } from 'bundlemon-utils';
 import { createProject, getOrCreateProjectId } from '../framework/mongo/projects';
 import { createHash } from '../utils/hashUtils';
+import { createOctokitClientByAction } from '../framework/github';
 
 import type { CreateProjectResponse } from 'bundlemon-utils';
-import type { RouteHandlerMethod } from 'fastify';
+import type { FastifyLoggerInstance, RouteHandlerMethod } from 'fastify';
 import type { FastifyValidatedRoute } from '../types/schemas';
 import type { GetOrCreateProjectIdRequestSchema } from '../types/schemas/projects';
 
@@ -23,9 +25,43 @@ export const getOrCreateProjectIdController: FastifyValidatedRoute<GetOrCreatePr
   req,
   res
 ) => {
-  const { provider, owner, repo } = req.body;
+  const { body, query } = req;
 
+  const authResult = await checkGetOrCreateProjectIdAuth({ body, query }, req.log);
+
+  if (!authResult.authenticated) {
+    res.status(403).send({ error: authResult.error, extraData: authResult.extraData });
+    return;
+  }
+
+  const { provider, owner, repo } = body;
   const id = await getOrCreateProjectId({ provider, owner: owner.toLowerCase(), repo: repo.toLowerCase() });
 
   res.send({ id });
 };
+
+type CheckAuthResponse =
+  | {
+      authenticated: false;
+      error: string;
+      extraData?: Record<string, any>;
+    }
+  | { authenticated: true };
+
+async function checkGetOrCreateProjectIdAuth(
+  { body, query }: GetOrCreateProjectIdRequestSchema,
+  log: FastifyLoggerInstance
+): Promise<CheckAuthResponse> {
+  const { provider, owner, repo } = body;
+
+  switch (provider) {
+    case ProjectProvider.GitHub: {
+      return createOctokitClientByAction({ owner, repo, runId: query.runId, commitSha: query.commitSha }, log);
+    }
+    default: {
+      log.warn({ provider }, 'unknown provider');
+
+      return { authenticated: false, error: 'forbidden' };
+    }
+  }
+}

--- a/service/src/framework/github.ts
+++ b/service/src/framework/github.ts
@@ -63,7 +63,7 @@ export async function createOctokitClientByAction(
 
   if (!installationId) {
     log.info({ owner, repo }, 'missing installation id');
-    return { authenticated: false, error: `BundleMon GitHub app is not installed on this repo (${owner}/${repo})` };
+    return { authenticated: false, error: `BundleMon GitHub app is not installed for this repo (${owner}/${repo})` };
   }
 
   const octokit = createOctokitClientByInstallationId(installationId);

--- a/service/src/routes/api/__tests__/commitRecordsRoutes.spec.ts
+++ b/service/src/routes/api/__tests__/commitRecordsRoutes.spec.ts
@@ -454,7 +454,8 @@ describe('commit records routes', () => {
           );
         });
 
-        test('not authenticated - git project', async () => {
+        // TODO: legacy github auth currently enabled
+        test.skip('not authenticated - git project', async () => {
           const mockedCreateOctokitClientByAction = mocked(createOctokitClientByAction);
           const project = await createTestGithubProject();
           const runId = String(generateRandomInt(1000000, 99999999));

--- a/service/src/routes/api/__tests__/projectsRoutes.spec.ts
+++ b/service/src/routes/api/__tests__/projectsRoutes.spec.ts
@@ -5,6 +5,10 @@ import { getProjectsCollection } from '../../../framework/mongo/projects';
 import { verifyHash } from '../../../utils/hashUtils';
 import { generateRandomString } from '@tests/utils';
 import { createTestGithubProject } from '@tests/projectUtils';
+import { createOctokitClientByAction } from '../../../framework/github';
+import { mocked } from 'ts-jest/utils';
+
+jest.mock('../../../framework/github');
 
 describe('projects routes', () => {
   test('create project', async () => {
@@ -38,81 +42,290 @@ describe('projects routes', () => {
   });
 
   describe('get or create project', () => {
-    test('project doesnt exist', async () => {
-      const provider = ProjectProvider.GitHub;
-      const owner = generateRandomString() + 'A.a';
-      const repo = generateRandomString() + 'B_-';
+    test('unknown provider', async () => {
+      const owner = generateRandomString();
+      const repo = generateRandomString();
+      const runId = generateRandomString();
+      const commitSha = generateRandomString();
       const response = await app.inject({
         method: 'POST',
         url: '/v1/projects/id',
         payload: {
-          provider,
+          provider: 'provider',
           owner,
           repo,
         },
-      });
-
-      expect(response.statusCode).toEqual(200);
-
-      const responseJson = response.json<{ id: string }>();
-
-      expect(responseJson.id).toBeDefined();
-
-      const projectsCollection = await getProjectsCollection();
-      const projectInDb = await projectsCollection.findOne({ _id: new ObjectId(responseJson.id) });
-
-      if (!projectInDb) {
-        throw Error('project should be in DB');
-      }
-
-      if (!('provider' in projectInDb)) {
-        // TODO: typescript
-        throw Error('project should have provider');
-      }
-
-      expect(projectInDb._id.toHexString()).toEqual(responseJson.id);
-      expect(projectInDb.provider).toEqual(provider);
-      expect(projectInDb.owner).toEqual(owner.toLowerCase());
-      expect(projectInDb.repo).toEqual(repo.toLowerCase());
-      expect(projectInDb.lastAccessed.getTime()).toEqual(projectInDb.creationDate.getTime());
-    });
-
-    test('project exist', async () => {
-      const project = await createTestGithubProject();
-
-      const response = await app.inject({
-        method: 'POST',
-        url: '/v1/projects/id',
-        payload: {
-          provider: project.provider,
-          owner: project.owner,
-          repo: project.repo,
+        query: {
+          runId,
+          commitSha,
         },
       });
 
-      expect(response.statusCode).toEqual(200);
+      expect(response.statusCode).toEqual(400);
+    });
 
-      const responseJson = response.json<{ id: string }>();
+    describe('GitHub project', () => {
+      const provider = ProjectProvider.GitHub;
 
-      expect(responseJson.id).toEqual(project.id);
+      describe('bad request', () => {
+        test.each([
+          {
+            name: 'missing owner',
+            payload: { repo: generateRandomString() },
+            query: { runId: generateRandomString(), commitSha: generateRandomString() },
+          },
+          {
+            name: 'missing repo',
+            payload: { repo: generateRandomString() },
+            query: { commitSha: generateRandomString() },
+          },
+          {
+            name: 'no query',
+            payload: { owner: generateRandomString(), repo: generateRandomString() },
+            query: undefined,
+          },
+          {
+            name: 'empty query',
+            payload: { owner: generateRandomString(), repo: generateRandomString() },
+            query: {},
+          },
+          {
+            name: 'missing runId',
+            payload: { owner: generateRandomString(), repo: generateRandomString() },
+            query: { commitSha: generateRandomString() },
+          },
+          {
+            name: 'missing commitSha',
+            payload: { owner: generateRandomString(), repo: generateRandomString() },
+            query: { runId: generateRandomString() },
+          },
+        ])('$name', async ({ payload, query }) => {
+          const response = await app.inject({
+            method: 'POST',
+            url: '/v1/projects/id',
+            payload: {
+              provider,
+              ...payload,
+            },
+            query: query as any,
+          });
 
-      const projectsCollection = await getProjectsCollection();
-      const projectInDb = await projectsCollection.findOne({ _id: new ObjectId(responseJson.id) });
+          expect(response.statusCode).toEqual(400);
+        });
+      });
 
-      if (!projectInDb) {
-        throw Error('project should be in DB');
-      }
+      test('project doesnt exist, authenticated', async () => {
+        const mockedCreateOctokitClientByAction = mocked(createOctokitClientByAction).mockResolvedValue({
+          authenticated: true,
+          installationOctokit: {} as any,
+        });
+        const owner = generateRandomString() + 'A.a';
+        const repo = generateRandomString() + 'B_-';
+        const runId = generateRandomString();
+        const commitSha = generateRandomString();
+        const response = await app.inject({
+          method: 'POST',
+          url: '/v1/projects/id',
+          payload: {
+            provider,
+            owner,
+            repo,
+          },
+          query: {
+            runId,
+            commitSha,
+          },
+        });
 
-      if (!('provider' in projectInDb)) {
-        // TODO: typescript
-        throw Error('project should have provider');
-      }
+        expect(response.statusCode).toEqual(200);
 
-      expect(projectInDb._id.toHexString()).toEqual(responseJson.id);
-      expect(projectInDb.provider).toEqual(project.provider);
-      expect(projectInDb.owner).toEqual(project.owner);
-      expect(projectInDb.repo).toEqual(project.repo);
-      expect(projectInDb.lastAccessed.getTime()).toBeGreaterThan(projectInDb.creationDate.getTime());
+        const responseJson = response.json<{ id: string }>();
+
+        expect(responseJson.id).toBeDefined();
+
+        const projectsCollection = await getProjectsCollection();
+        const projectInDb = await projectsCollection.findOne({ _id: new ObjectId(responseJson.id) });
+
+        if (!projectInDb) {
+          throw Error('project should be in DB');
+        }
+
+        if (!('provider' in projectInDb)) {
+          // TODO: typescript
+          throw Error('project should have provider');
+        }
+
+        expect(mockedCreateOctokitClientByAction).toHaveBeenCalledWith(
+          {
+            owner,
+            repo,
+            commitSha,
+            runId,
+          },
+          expect.any(Object)
+        );
+        expect(projectInDb._id.toHexString()).toEqual(responseJson.id);
+        expect(projectInDb.provider).toEqual(provider);
+        expect(projectInDb.owner).toEqual(owner.toLowerCase());
+        expect(projectInDb.repo).toEqual(repo.toLowerCase());
+        expect(projectInDb.lastAccessed.getTime()).toEqual(projectInDb.creationDate.getTime());
+      });
+
+      test('project doesnt exist, not authenticated', async () => {
+        const projectsCollection = await getProjectsCollection();
+        const beforeProjectsInDb = await projectsCollection.countDocuments();
+
+        const errorMsg = 'some message';
+        const mockedCreateOctokitClientByAction = mocked(createOctokitClientByAction).mockResolvedValue({
+          authenticated: false,
+          error: errorMsg,
+        });
+        const owner = generateRandomString() + 'A.a';
+        const repo = generateRandomString() + 'B_-';
+        const runId = generateRandomString();
+        const commitSha = generateRandomString();
+        const response = await app.inject({
+          method: 'POST',
+          url: '/v1/projects/id',
+          payload: {
+            provider,
+            owner,
+            repo,
+          },
+          query: {
+            runId,
+            commitSha,
+          },
+        });
+
+        expect(response.statusCode).toEqual(403);
+
+        const responseJson = response.json();
+
+        expect(responseJson.error).toEqual(errorMsg);
+
+        expect(mockedCreateOctokitClientByAction).toHaveBeenCalledWith(
+          {
+            owner,
+            repo,
+            commitSha,
+            runId,
+          },
+          expect.any(Object)
+        );
+        expect(await projectsCollection.countDocuments()).toEqual(beforeProjectsInDb);
+      });
+
+      test('project exist, authenticated', async () => {
+        const mockedCreateOctokitClientByAction = mocked(createOctokitClientByAction).mockResolvedValue({
+          authenticated: true,
+          installationOctokit: {} as any,
+        });
+        const project = await createTestGithubProject();
+        const runId = generateRandomString();
+        const commitSha = generateRandomString();
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/v1/projects/id',
+          payload: {
+            provider: project.provider,
+            owner: project.owner,
+            repo: project.repo,
+          },
+          query: {
+            runId,
+            commitSha,
+          },
+        });
+
+        expect(response.statusCode).toEqual(200);
+
+        const responseJson = response.json<{ id: string }>();
+
+        expect(responseJson.id).toEqual(project.id);
+
+        const projectsCollection = await getProjectsCollection();
+        const projectInDb = await projectsCollection.findOne({ _id: new ObjectId(responseJson.id) });
+
+        if (!projectInDb) {
+          throw Error('project should be in DB');
+        }
+
+        if (!('provider' in projectInDb)) {
+          // TODO: typescript
+          throw Error('project should have provider');
+        }
+
+        expect(mockedCreateOctokitClientByAction).toHaveBeenCalledWith(
+          {
+            owner: project.owner,
+            repo: project.repo,
+            commitSha,
+            runId,
+          },
+          expect.any(Object)
+        );
+        expect(projectInDb._id.toHexString()).toEqual(responseJson.id);
+        expect(projectInDb.provider).toEqual(project.provider);
+        expect(projectInDb.owner).toEqual(project.owner);
+        expect(projectInDb.repo).toEqual(project.repo);
+        expect(projectInDb.lastAccessed.getTime()).toBeGreaterThan(project.lastAccessed.getTime());
+      });
+
+      test('project exist, not authenticated', async () => {
+        const errorMsg = 'some message';
+        const mockedCreateOctokitClientByAction = mocked(createOctokitClientByAction).mockResolvedValue({
+          authenticated: false,
+          error: errorMsg,
+        });
+        const project = await createTestGithubProject();
+        const runId = generateRandomString();
+        const commitSha = generateRandomString();
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/v1/projects/id',
+          payload: {
+            provider: project.provider,
+            owner: project.owner,
+            repo: project.repo,
+          },
+          query: {
+            runId,
+            commitSha,
+          },
+        });
+
+        expect(response.statusCode).toEqual(403);
+
+        const responseJson = response.json();
+
+        expect(responseJson.error).toEqual(errorMsg);
+
+        const projectsCollection = await getProjectsCollection();
+        const projectInDb = await projectsCollection.findOne({ _id: new ObjectId(project.id) });
+
+        if (!projectInDb) {
+          throw Error('project should be in DB');
+        }
+
+        if (!('provider' in projectInDb)) {
+          // TODO: typescript
+          throw Error('project should have provider');
+        }
+
+        expect(mockedCreateOctokitClientByAction).toHaveBeenCalledWith(
+          {
+            owner: project.owner,
+            repo: project.repo,
+            commitSha,
+            runId,
+          },
+          expect.any(Object)
+        );
+        expect(projectInDb.lastAccessed.getTime()).toEqual(projectInDb.creationDate.getTime());
+      });
     });
   });
 });

--- a/service/src/types/schemas/commitRecords.ts
+++ b/service/src/types/schemas/commitRecords.ts
@@ -8,17 +8,26 @@ import type {
 } from '../../consts/commitRecords';
 import type { BaseRequestSchema, BaseGetRequestSchema, AuthHeaders, ProjectIdParams } from './common';
 
+export type CreateCommitRecordProjectApiKeyAuthQuery = {
+  authType: CreateCommitRecordAuthType.ProjectApiKey;
+  token: string;
+};
+
 export type CreateCommitRecordGithubActionsAuthQuery = {
   authType: CreateCommitRecordAuthType.GithubActions;
   runId: string;
 };
 
-export type CreateCommitRecordRequestQuery = CreateCommitRecordGithubActionsAuthQuery | Record<string, never>;
+export type CreateCommitRecordRequestQuery =
+  | CreateCommitRecordProjectApiKeyAuthQuery
+  | CreateCommitRecordGithubActionsAuthQuery
+  | Record<string, never>;
 
 export interface CreateCommitRecordRequestSchema extends BaseRequestSchema {
   body: CommitRecordPayload;
   params: ProjectIdParams;
   query: CreateCommitRecordRequestQuery;
+  // @deprecated
   headers: AuthHeaders;
 }
 

--- a/service/src/types/schemas/githubOutput.ts
+++ b/service/src/types/schemas/githubOutput.ts
@@ -86,8 +86,9 @@ interface GithubOutputBody {
     repo: string;
     commitSha: string;
     prNumber?: string;
-  } & ({ token: string } | { runId: string });
+  };
   output: Partial<Record<GithubOutputTypes, boolean>>;
+  auth: { token: string } | { runId: string };
 }
 
 export interface GithubOutputRequestSchema extends BaseRequestSchema {

--- a/service/src/types/schemas/projects.ts
+++ b/service/src/types/schemas/projects.ts
@@ -1,8 +1,16 @@
 /* istanbul ignore file */
 
+import { ProjectProvider } from 'bundlemon-utils';
 import { GitDetails } from '../../types';
-import type { BaseRequestSchema } from './common';
 
-export interface GetOrCreateProjectIdRequestSchema extends BaseRequestSchema {
-  body: GitDetails;
-}
+type GithubProviderAuthQuery = {
+  runId: string;
+  commitSha: string;
+};
+
+type GithubProviderRequest = {
+  body: Omit<GitDetails, 'provider'> & { provider: ProjectProvider.GitHub };
+  query: GithubProviderAuthQuery;
+};
+
+export type GetOrCreateProjectIdRequestSchema = GithubProviderRequest;


### PR DESCRIPTION
related: #103 

This PR introduces an automatic way to create a project if your repo is hosted on GitHub and using GitHub Actions.

Currently, if BundleMon GitHub app is installed for your repo, you can create GitHub outputs by using project API key, which due to recent finds, may be exploited.

**After the release of BundleMon CLI v2, v1 will be deprecated and will stop working in a few months.**

Create GitHub outputs by using one of the options:
1. Providing GitHub access token.
2. Have the BundleMon GitHub app installed and run BundleMon CLI in GitHub actions.
