### PR TITLE
Add a note about CI_TARGET_BRANCH for CircleCI in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ In order to save history and get differences from your main branches you will ne
 
 In order to get BundleMon to work you'll need to set these environment variables:
 
-> If you are using one of the supported CIs (GitHub Actions, Travis, CircleCI and Codefresh) you dont need to set anything.
+> If you are using one of the supported CIs (GitHub Actions, Travis and Codefresh) you dont need to set anything. CircleCI is also supported, but you need to manually set `CI_TARGET_BRANCH`.
 
 - `CI=true`
 - `CI_REPO_OWNER` - github.com/LironEr/bundlemon `LironEr`


### PR DESCRIPTION
With CircleCI, we need to manually set `CI_TARGET_BRANCH`, so I'm updating the readme to match that.
https://github.com/LironEr/bundlemon/blob/7c99feec8fc6d7e5ea0c6637a24c50dd34c3833f/packages/bundlemon/src/main/utils/ci/providers/circleCI.ts#L15-L18 