### PR TITLE
feat: use Github token only to verify the owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,16 +147,17 @@ BundleMon can create GitHub check run, post commit status and a detailed comment
 <br />
 <img src="./assets/pr-comment.png" alt="GitHub detailed comment" height="300px" />
 
-1. Setup integration
+1. [Install BundleMon GitHub App](https://github.com/apps/bundlemon)
+2. Setup integration
 
-   - If BundleMon runs in GitHub actions and you already [Installed BundleMon GitHub App](https://github.com/apps/bundlemon) you can go to step 2.
-   - If BundleMon not runs In GitHub actions you will need to [create GitHub access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with `repo:*` scope.
+   - If BundleMon runs in GitHub actions you can go to step 2.
+   - If BundleMon not runs In GitHub actions you will need to [create GitHub access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) without any scopes, the token owner must have write permission to the repo you would want to post outputs to.
 
      Add the token to `BUNDLEMON_GITHUB_TOKEN` environment variable in your CI.
 
-     > The token is not saved in BundleMon service, ONLY used to communicate with GitHub
+     > The token is not saved in BundleMon service, ONLY used to verify the username that created the token.
 
-2. Add `github` to `reportOutput`
+3. Add `github` to `reportOutput`
 
    ```json
    "reportOutput": ["github"]

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -8,8 +8,8 @@
 
 - If you are using a different CI provider (Travis, CircleCI, etc) you must provide a project API key. **From now on you will need to provide a GitHub access token** if you want to integrate with GitHub (post commit status / pr comment).
 
-  - [Create GitHub access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with `repo:*` scope.
+  - [Create GitHub access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) without any scopes, the token owner must have write permission to the repo you would want to post outputs to.
 
   - Add the token to `BUNDLEMON_GITHUB_TOKEN` environment variable in your CI.
 
-    > The token is not saved in BundleMon service, ONLY used to communicate with GitHub
+    > The token is not saved in BundleMon service, ONLY used to verify the username that created the token.

--- a/service/src/controllers/commitRecordsController.ts
+++ b/service/src/controllers/commitRecordsController.ts
@@ -3,10 +3,10 @@ import {
   createCommitRecord,
   getCommitRecords,
   getCommitRecordWithBase,
-} from '../framework/mongo/commitRecords';
+} from '@/framework/mongo/commitRecords';
 import { checkAuth } from './utils/auth';
-import { generateLinkToReport } from '../utils/linkUtils';
-import { BaseRecordCompareTo } from '../consts/commitRecords';
+import { generateLinkToReport } from '@/utils/linkUtils';
+import { BaseRecordCompareTo } from '@/consts/commitRecords';
 
 import type {
   FastifyValidatedRoute,
@@ -14,7 +14,7 @@ import type {
   GetCommitRecordRequestSchema,
   GetCommitRecordsRequestSchema,
   ReviewCommitRecordRequestSchema,
-} from '../types/schemas';
+} from '@/types/schemas';
 
 import { CommitRecord, CommitRecordReview, CreateCommitRecordResponse } from 'bundlemon-utils';
 import { generateReport } from '@/utils/reportUtils';
@@ -23,6 +23,7 @@ import {
   createOctokitClientByToken,
   updateGithubOutputs,
   isUserHasWritePermissionToRepo,
+  getCurrentUser,
 } from '@/framework/github';
 import { setProjectLastRecordDate } from '@/framework/mongo/projects';
 
@@ -144,10 +145,12 @@ export const reviewCommitRecordController: FastifyValidatedRoute<ReviewCommitRec
   }
 
   const userOctokit = createOctokitClientByToken(user.auth.token);
+  const githubUser = await getCurrentUser(userOctokit);
   const hasPermission = await isUserHasWritePermissionToRepo(
     userOctokit,
     commitRecordGitHubOutputs.owner,
-    commitRecordGitHubOutputs.repo
+    commitRecordGitHubOutputs.repo,
+    githubUser.login
   );
 
   if (!hasPermission) {

--- a/service/src/framework/github.ts
+++ b/service/src/framework/github.ts
@@ -357,13 +357,11 @@ export async function getCurrentUser(octokit: Octokit) {
   return data;
 }
 
-export async function isUserHasWritePermissionToRepo(octokit: Octokit, owner: string, repo: string) {
-  const user = await getCurrentUser(octokit);
-
+export async function isUserHasWritePermissionToRepo(octokit: Octokit, owner: string, repo: string, username: string) {
   const { data } = await octokit.repos.getCollaboratorPermissionLevel({
     owner,
     repo,
-    username: user.login,
+    username,
   });
 
   return WRITE_PERMISSIONS.includes(data.permission);

--- a/service/src/routes/api/__tests__/commitRecordsRoutes/reviewCommitRecord.spec.ts
+++ b/service/src/routes/api/__tests__/commitRecordsRoutes/reviewCommitRecord.spec.ts
@@ -18,6 +18,7 @@ import {
   updateGithubOutputs,
   isUserHasWritePermissionToRepo,
   createOctokitClientByRepo,
+  getCurrentUser,
 } from '@/framework/github';
 import { ReviewCommitRecordRequestSchema } from '@/types/schemas';
 
@@ -116,6 +117,7 @@ describe('review commit record', () => {
 
   test('no GitHub outputs on record', async () => {
     jest.mocked(createOctokitClientByToken).mockReturnValue({} as any);
+    jest.mocked(getCurrentUser).mockResolvedValue({ login: 'username' } as any);
     jest.mocked(isUserHasWritePermissionToRepo).mockResolvedValue(true);
 
     const project = await createTestGithubProject();
@@ -208,6 +210,7 @@ describe('review commit record', () => {
 
   test('no write permissions to GitHub repo', async () => {
     jest.mocked(createOctokitClientByToken).mockReturnValue({} as any);
+    jest.mocked(getCurrentUser).mockResolvedValue({ login: 'username' } as any);
     jest.mocked(isUserHasWritePermissionToRepo).mockResolvedValue(false);
 
     const project = await createTestGithubProject();
@@ -258,6 +261,7 @@ describe('review commit record', () => {
   test('GitHub app is not installed for this repo', async () => {
     jest.mocked(createOctokitClientByToken).mockReturnValue({} as any);
     jest.mocked(createOctokitClientByRepo).mockResolvedValue(undefined);
+    jest.mocked(getCurrentUser).mockResolvedValue({ login: 'username' } as any);
     jest.mocked(isUserHasWritePermissionToRepo).mockResolvedValue(true);
 
     const project = await createTestGithubProject();
@@ -313,6 +317,7 @@ describe('review commit record', () => {
   test('success first approver', async () => {
     const mockedCreateOctokitClientByToken = jest.mocked(createOctokitClientByToken).mockReturnValue({} as any);
     const mockedCreateOctokitClientByRepo = jest.mocked(createOctokitClientByRepo).mockResolvedValue({} as any);
+    jest.mocked(getCurrentUser).mockResolvedValue({ login: 'username' } as any);
     const mockedIsUserHasWritePermissionToRepo = jest.mocked(isUserHasWritePermissionToRepo).mockResolvedValue(true);
     jest.mocked(updateGithubOutputs).mockResolvedValue();
 
@@ -376,7 +381,8 @@ describe('review commit record', () => {
     expect(mockedIsUserHasWritePermissionToRepo).toHaveBeenCalledWith(
       expect.any(Object),
       githubOutputs.owner,
-      githubOutputs.repo
+      githubOutputs.repo,
+      'username'
     );
     expect(mockedCreateOctokitClientByRepo).toHaveBeenCalledWith(githubOutputs.owner, githubOutputs.repo);
     expect(updateGithubOutputs).toHaveBeenCalledTimes(1);
@@ -385,6 +391,7 @@ describe('review commit record', () => {
   test('success with existing user reviews', async () => {
     const mockedCreateOctokitClientByToken = jest.mocked(createOctokitClientByToken).mockReturnValue({} as any);
     const mockedCreateOctokitClientByRepo = jest.mocked(createOctokitClientByRepo).mockResolvedValue({} as any);
+    jest.mocked(getCurrentUser).mockResolvedValue({ login: 'username' } as any);
     const mockedIsUserHasWritePermissionToRepo = jest.mocked(isUserHasWritePermissionToRepo).mockResolvedValue(true);
     jest.mocked(updateGithubOutputs).mockResolvedValue();
 
@@ -485,7 +492,8 @@ describe('review commit record', () => {
     expect(mockedIsUserHasWritePermissionToRepo).toHaveBeenCalledWith(
       expect.any(Object),
       githubOutputs.owner,
-      githubOutputs.repo
+      githubOutputs.repo,
+      'username'
     );
     expect(mockedCreateOctokitClientByRepo).toHaveBeenCalledWith(githubOutputs.owner, githubOutputs.repo);
     expect(updateGithubOutputs).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
With this method, users can create a GitHub token without any scope.

This will also allow users that use GitHub tokens to create check runs.

related #147 