### PR TITLE
Changed hash regex to allow for `_` and `-` in hashes.

### DIFF
--- a/packages/bundlemon/src/main/analyzer/__tests__/__snapshots__/pathUtils.spec.ts.snap
+++ b/packages/bundlemon/src/main/analyzer/__tests__/__snapshots__/pathUtils.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`getFiles getAllPaths empty directory 1`] = `[]`;
 
-exports[`getFiles getRegexHash 1`] = `"(?<hash0>[a-zA-Z0-9]+)"`;
+exports[`getFiles getRegexHash 1`] = `"(?<hash0>[\\w-]+)"`;
 
-exports[`getFiles getRegexHash 2`] = `"(?<hash0>[a-zA-Z0-9]+)"`;
+exports[`getFiles getRegexHash 2`] = `"(?<hash0>[\\w-]+)"`;

--- a/packages/bundlemon/src/main/analyzer/__tests__/pathUtils.spec.ts
+++ b/packages/bundlemon/src/main/analyzer/__tests__/pathUtils.spec.ts
@@ -90,7 +90,7 @@ describe('getFiles', () => {
     const files = [
       path.join(fixturePath, 'index.html'),
       path.join(fixturePath, 'service.js'),
-      path.join(fixturePath, 'static/js/about.hjasj2u.js'),
+      path.join(fixturePath, 'static/js/about.hja-sj2u.js'),
       path.join(fixturePath, 'static/js/login.a2j21i.js'),
       path.join(fixturePath, 'static/js/main.jh2j2ks.js'),
       path.join(fixturePath, 'static/js/other.js'),
@@ -116,7 +116,7 @@ describe('getFiles', () => {
           { fullPath: path.join(fixturePath, '/static/js/other.js'), prettyPath: 'static/js/other.js' },
         ],
         '**/*.<hash>.js': [
-          { fullPath: path.join(fixturePath, '/static/js/about.hjasj2u.js'), prettyPath: 'static/js/about.(hash).js' },
+          { fullPath: path.join(fixturePath, '/static/js/about.hja-sj2u.js'), prettyPath: 'static/js/about.(hash).js' },
           { fullPath: path.join(fixturePath, '/static/js/login.a2j21i.js'), prettyPath: 'static/js/login.(hash).js' },
         ],
         '**/main.<hash>.js': [
@@ -146,7 +146,10 @@ describe('getFiles', () => {
         'index.html': [{ fullPath: path.join(fixturePath, '/index.html'), prettyPath: 'index.html' }],
         '**/*.js': [
           { fullPath: path.join(fixturePath, '/service.js'), prettyPath: 'service.js' },
-          { fullPath: path.join(fixturePath, '/static/js/about.hjasj2u.js'), prettyPath: 'static/js/about.hjasj2u.js' },
+          {
+            fullPath: path.join(fixturePath, '/static/js/about.hja-sj2u.js'),
+            prettyPath: 'static/js/about.hja-sj2u.js',
+          },
           { fullPath: path.join(fixturePath, '/static/js/login.a2j21i.js'), prettyPath: 'static/js/login.a2j21i.js' },
           { fullPath: path.join(fixturePath, '/static/js/main.jh2j2ks.js'), prettyPath: 'static/js/main.jh2j2ks.js' },
           { fullPath: path.join(fixturePath, '/static/js/other.js'), prettyPath: 'static/js/other.js' },

--- a/packages/bundlemon/src/main/analyzer/pathUtils.ts
+++ b/packages/bundlemon/src/main/analyzer/pathUtils.ts
@@ -30,7 +30,7 @@ export function createPrettyPath(filePath: string, globPattern: string): string 
 }
 
 export function getRegexHash(index: number): string {
-  return `(?<hash${index}>[a-zA-Z0-9]+)`;
+  return `(?<hash${index}>[\\w-]+)`;
 }
 
 export async function getMatchFiles(


### PR DESCRIPTION
[Based on the discussion I opened recently](https://github.com/LironEr/bundlemon/discussions/191) I decided to do some digging and thought I would propose a change here.
My proposal is to open up the hash regex to allow for `_` and `-` characters in addition to the current ones (`a-z`, `A-Z` and `0-9`). This would make Bundlemon compatible with hashes generated by Rollup 4.
I realize that this is potentially a breaking change for users of `Bundlemon` who rely on the specifics of the current regex. Potentially this could be a configuration option instead that allows for different hashes. What do you think?