### PR TITLE
build(deps-dev): upgrade cosmiconfig to v8.3.6

### DIFF
--- a/packages/bundlemon/package.json
+++ b/packages/bundlemon/package.json
@@ -35,7 +35,7 @@
     "bytes": "^3.1.2",
     "chalk": "^4.0.0",
     "commander": "^11.1.0",
-    "cosmiconfig": "^7.0.1",
+    "cosmiconfig": "^8.3.6",
     "gzip-size": "^6.0.0",
     "micromatch": "^4.0.5",
     "yup": "^0.32.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6348,7 +6348,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
+cosmiconfig@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
   integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
@@ -6359,7 +6359,7 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cosmiconfig@^8.1.3:
+cosmiconfig@^8.1.3, cosmiconfig@^8.3.6:
   version "8.3.6"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.3.6.tgz#060a2b871d66dba6c8538ea1118ba1ac16f5fae3"
   integrity sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==


### PR DESCRIPTION
There should be no significant breaking changes by upgrading to v8 (https://github.com/cosmiconfig/cosmiconfig/blob/main/CHANGELOG.md#800) it just drops support for older versions of NodeJS.

I'm trying to avoid new CommonJS files in my repo & the benefit to this change will be supporting ESM by default: https://github.com/cosmiconfig/cosmiconfig/issues/224

However, there is a workaround with `resolutions` in my `package.json`:
```
  "resolutions": {
    "cosmiconfig": "^8.3.6"
  },
```  

---
Note: there is a more recent major version of `cosmiconfig` (https://github.com/cosmiconfig/cosmiconfig/blob/main/CHANGELOG.md#900) but since there are more significant breaking changes I elected to suggest v8.